### PR TITLE
destroyアクションのルーティング設定と定義、showビュー修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,7 +5,7 @@ class ItemsController < ApplicationController
   before_action :item_find, only:[:show, :edit, :update, :destroy]
 
   #出品者でなければトップページに遷移する
-  before_action :go_toppage, only:[:edit, :destroy]
+  before_action :go_toppage, only:[:edit, :update, :destroy]
 
   def index
     @items = Item.includes(:user).order("created_at DESC")

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,6 +4,9 @@ class ItemsController < ApplicationController
   # 重複処理をまとめる
   before_action :item_find, only:[:show, :edit, :update, :destroy]
 
+  #出品者でなければトップページに遷移する
+  before_action :go_toppage, only:[:edit, :destroy]
+
   def index
     @items = Item.includes(:user).order("created_at DESC")
   end
@@ -41,10 +44,8 @@ class ItemsController < ApplicationController
   def destroy
     # ログインしているユーザーと同一であればデータを削除する
     if @item.user_id == current_user.id
-      @item.destroy
-      redirect_to root_path
-    else
-      redirect_to root_path
+       @item.destroy
+       redirect_to root_path
     end
   end
 
@@ -56,6 +57,12 @@ class ItemsController < ApplicationController
 
   def item_find
     @item = Item.find(params[:id])
+  end
+
+  def go_toppage
+    unless @item.user_id == current_user.id
+      redirect_to root_path
+    end
   end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,9 +28,6 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    unless @item.user_id == current_user.id
-      redirect_to root_path
-    end
   end
 
   def update
@@ -42,11 +39,8 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    # ログインしているユーザーと同一であればデータを削除する
-    if @item.user_id == current_user.id
        @item.destroy
        redirect_to root_path
-    end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
   # 重複処理をまとめる
-  before_action :item_find, only:[:show, :edit, :update]
+  before_action :item_find, only:[:show, :edit, :update, :destroy]
 
   def index
     @items = Item.includes(:user).order("created_at DESC")
@@ -38,15 +38,15 @@ class ItemsController < ApplicationController
     end
   end
 
-  # def destroy
-  #   # ログインしているユーザーと同一であればデータを削除する
-  #   if @item.user_id == current_user.id
-  #     @item.destroy
-  #     redirect_to root_path
-  #   else
-  #     redirect_to root_path
-  #   end
-  # end
+  def destroy
+    # ログインしているユーザーと同一であればデータを削除する
+    if @item.user_id == current_user.id
+      @item.destroy
+      redirect_to root_path
+    else
+      redirect_to root_path
+    end
+  end
 
   private
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
       <% if current_user.id == @item.user.id %>
         <%= link_to "商品の編集", edit_item_path(@item) , method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item), method: :delete, class:"item-destroy" %>
       <%# 出品者以外のときの表示%>
       <% else %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,5 @@ Rails.application.routes.draw do
   get 'items/index'
   root to: 'items#index'
 
-  resources :items, only: [:index, :new, :create, :show, :edit, :update ]
+  resources :items
 end


### PR DESCRIPTION
# what
商品削除機能実装

# why
商品削除機能実装のため

# ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/4ee4fe997189b19619d38721ee2bfbb7